### PR TITLE
Remove Newtonsoft.Json in favor of System.Text.Json

### DIFF
--- a/PostHog.NET/Config.cs
+++ b/PostHog.NET/Config.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Text.Json;
 
 namespace PostHog
 {
@@ -45,5 +46,7 @@ namespace PostHog
         public TimeSpan Timeout { get; set; }
 
         public string UserAgent { get; set; }
+
+        public JsonSerializerOptions JsonSerializerOptions { get; set; } = new JsonSerializerOptions();
     }
 }

--- a/PostHog.NET/Model/BaseAction.cs
+++ b/PostHog.NET/Model/BaseAction.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace PostHog.Model
 {
@@ -13,19 +13,19 @@ namespace PostHog.Model
             Timestamp = timestamp ?? DateTime.UtcNow;
         }
 
-        [JsonProperty(PropertyName = "distinct_id")]
+        [JsonPropertyName(name: "distinct_id")]
         public string? DistinctId { get; set; }
 
-        [JsonProperty(PropertyName = "event")]
+        [JsonPropertyName(name: "event")]
         public string Event { get; set; }
 
-        [JsonProperty(PropertyName = "properties")]
+        [JsonPropertyName(name: "properties")]
         public Properties? Properties { get; set; }
 
         [JsonIgnore]
         public int Size { get; set; }
 
-        [JsonProperty(PropertyName = "timestamp")]
+        [JsonPropertyName(name: "timestamp")]
         public DateTime Timestamp { get; set; }
     }
 }

--- a/PostHog.NET/Model/Batch.cs
+++ b/PostHog.NET/Model/Batch.cs
@@ -1,5 +1,5 @@
 ﻿using System.Collections.Generic;
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace PostHog.Model
 {
@@ -11,10 +11,10 @@ namespace PostHog.Model
             ApiKey = apiKey;
         }
 
-        [JsonProperty(PropertyName = "batch")]
+        [JsonPropertyName(name: "batch")]
         internal List<BaseAction> Actions { get; set; }
 
-        [JsonProperty(PropertyName = "api_key")]
+        [JsonPropertyName(name: "api_key")]
         internal string ApiKey { get; set; }
     }
 }

--- a/PostHog.NET/Model/Properties.cs
+++ b/PostHog.NET/Model/Properties.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace PostHog.Model
 {

--- a/PostHog.NET/PostHog.NET.csproj
+++ b/PostHog.NET/PostHog.NET.csproj
@@ -21,7 +21,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="System.Text.Json" Version="8.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/PostHog.NET/PostHogClient.cs
+++ b/PostHog.NET/PostHogClient.cs
@@ -28,14 +28,14 @@ namespace PostHog
 
             if (config.MaxRetryTime.HasValue)
             {
-                requestHandler = new BlockingRequestHandler(this, config.Timeout, new Backoff(max: (Convert.ToInt32(config.MaxRetryTime.Value.TotalSeconds) * 1000), jitter: 5000));
+                requestHandler = new BlockingRequestHandler(this, config.Timeout, config.JsonSerializerOptions, new Backoff(max: (Convert.ToInt32(config.MaxRetryTime.Value.TotalSeconds) * 1000), jitter: 5000));
             }
             else
             {
-                requestHandler = new BlockingRequestHandler(this, config.Timeout);
+                requestHandler = new BlockingRequestHandler(this, config.Timeout, config.JsonSerializerOptions);
             }
 
-            _flushHandler = new AsyncIntervalFlushHandler(requestHandler, config.MaxQueueSize, config.FlushAt, config.FlushInterval, config.Threads, apiKey);
+            _flushHandler = new AsyncIntervalFlushHandler(requestHandler, config.MaxQueueSize, config.FlushAt, config.FlushInterval, config.Threads, apiKey, config.JsonSerializerOptions);
         }
 
         public Config Config { get; }

--- a/PostHog.NET/Request/BlockingRequestHandler.cs
+++ b/PostHog.NET/Request/BlockingRequestHandler.cs
@@ -6,8 +6,8 @@ using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
+using System.Text.Json;
 using System.Threading.Tasks;
-using Newtonsoft.Json;
 using PostHog.Exceptions;
 using PostHog.Model;
 
@@ -15,8 +15,10 @@ namespace PostHog.Request
 {
     internal class BlockingRequestHandler : IRequestHandler
     {
+        private readonly JsonSerializerOptions _jsonSerializerOptions;
+
         /// <summary>
-        /// Segment.io client to mark statistics
+        /// PostHog client to mark statistics
         /// </summary>
         private readonly PostHogClient _client;
 
@@ -30,13 +32,14 @@ namespace PostHog.Request
         /// </summary>
         public TimeSpan Timeout { get; set; }
 
-        internal BlockingRequestHandler(PostHogClient client, TimeSpan timeout) : this(client, timeout, new Backoff(max: 10000, jitter: 5000))
+        internal BlockingRequestHandler(PostHogClient client, TimeSpan timeout, JsonSerializerOptions jsonSerializerOptions) : this(client, timeout, jsonSerializerOptions, new Backoff(max: 10000, jitter: 5000))
         {
         }
 
-        internal BlockingRequestHandler(PostHogClient client, TimeSpan timeout, Backoff backoff)
+        internal BlockingRequestHandler(PostHogClient client, TimeSpan timeout, JsonSerializerOptions jsonSerializerOptions, Backoff backoff)
         {
             _client = client ?? throw new ArgumentNullException(nameof(client));
+            _jsonSerializerOptions = jsonSerializerOptions;
             _backoff = backoff;
 
             Timeout = timeout;
@@ -65,7 +68,7 @@ namespace PostHog.Request
 
                 var uri = uriBuilder.Uri;
 
-                var json = JsonConvert.SerializeObject(batch);
+                var json = JsonSerializer.Serialize(batch, _jsonSerializerOptions);
 
                 // Prepare request data;
                 var requestData = Encoding.UTF8.GetBytes(json);

--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ You can get PostHog.NET by [grabbing the latest NuGet package](https://www.nuget
 Register the service
 ```
 services.AddPostHog("api-key", config =>
-            {
-                // leave empty if you are not self-hosting 
-                config.Host = "example.com";
-            });
+{
+    // leave empty if you are not self-hosting 
+    config.Host = "example.com";
+});
 ```
 
 Inject IPostHogClient 
@@ -35,6 +35,17 @@ var properties = new Properties()
                 .SetUserPopertyOnce("user-property-to-set-once", "value"); // $set_once equivalent
 
 _postHogClient.Capture("a86818cc-c84e-4453-9c48-d7bb636e7f2d", "Fetch weather forecast", properties);
+```
+
+## Configure serialization
+
+Since event property values can be complex objects, you can also configure the JSON serialization options used to serialize the events:
+
+```csharp
+services.AddPostHog("api-key", config =>
+{
+    config.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+});
 ```
 
 ## Thanks

--- a/Sample/Program.cs
+++ b/Sample/Program.cs
@@ -1,3 +1,4 @@
+using System.Text.Json.Serialization;
 using PostHog.DI;
 
 namespace Sample
@@ -17,6 +18,7 @@ namespace Sample
             {
                 // leave empty if you are not self-hosting 
                 config.Host = "example.com";
+                config.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
             });
 
             var app = builder.Build();

--- a/Test/Model/PropertiesTests_Serialize.cs
+++ b/Test/Model/PropertiesTests_Serialize.cs
@@ -1,9 +1,7 @@
 ﻿using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Newtonsoft.Json;
 using PostHog.Model;
-using System.Collections.Generic;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
 
 namespace Test.Model
 {
@@ -18,15 +16,9 @@ namespace Test.Model
                 .SetUserProperty("user", "userValue")
                 .SetUserPropertyOnce("user_once", "user_once_value");
 
-            var json = JsonConvert.SerializeObject(properties);
-            var deserializedJson = JsonConvert.DeserializeObject<Properties>(json);
+            var json = JsonSerializer.Serialize(properties);
 
-            deserializedJson.Should().NotBeNull();
-            deserializedJson.Count.Should().Be(3);
-
-            deserializedJson["event"].Should().Be("event_value");
-            deserializedJson["$set"].Should().BeEquivalentTo(new Dictionary<string, object>() { { "user", (JValue)"userValue" } });
-            deserializedJson["$set_once"].Should().BeEquivalentTo(new Dictionary<string, object>() { { "user_once", (JValue)"user_once_value" } });
+            json.Should().Be("{\"event\":\"event_value\",\"$set\":{\"user\":\"userValue\"},\"$set_once\":{\"user_once\":\"user_once_value\"}}");
         }
     }
 }


### PR DESCRIPTION
Not sure if you're open to a change like this, but since most .NET projects are moving towards System.Text.Json being the standard JSON serializer, I've made some changes to this package to use that here.
This PR also exposes the serializer options to consumers so that it's much easier to ensure serialization of objects on event properties can be done in a compatible way.
Let me know what you think!