### PR TITLE
fix: serialize batch requests correctly

### DIFF
--- a/PostHog.NET/Model/Batch.cs
+++ b/PostHog.NET/Model/Batch.cs
@@ -3,18 +3,18 @@ using System.Text.Json.Serialization;
 
 namespace PostHog.Model
 {
-    internal class Batch
+    public class Batch
     {
-        internal Batch(List<BaseAction> actions, string apiKey)
+        public Batch(List<BaseAction> actions, string apiKey)
         {
             Actions = actions;
             ApiKey = apiKey;
         }
 
         [JsonPropertyName(name: "batch")]
-        internal List<BaseAction> Actions { get; set; }
+        public List<BaseAction> Actions { get; set; }
 
         [JsonPropertyName(name: "api_key")]
-        internal string ApiKey { get; set; }
+        public string ApiKey { get; set; }
     }
 }


### PR DESCRIPTION
Batch requests are not serialized correcly since `System.Text.Json` does not serialize `internal` properties.
This change fixes that by making the `Batch` `public`. 